### PR TITLE
Fix function mismatching on key

### DIFF
--- a/pkgs/harnica-midi/src/analysis/getChordFunctionOnKey.spec.ts
+++ b/pkgs/harnica-midi/src/analysis/getChordFunctionOnKey.spec.ts
@@ -17,17 +17,31 @@ describe("getChordFunctionOnKey", () => {
   it.only.each(
     // prettier-ignore
     [
-      { chord: "I", key: "C", actual: { ...allFalse, tonic: "perfect", } },
-      { chord: "V", key: "C", actual: { ...allFalse, dominant: "perfect" } },
-      { chord: "IV", key: "C", actual: { ...allFalse, subdominant: "perfect" } },
-      { chord: "IIm", key: "C", actual: { ...allFalse, secondSubDominant: "perfect" } },
-      { chord: "IIIm", key: "C", actual: { ...allFalse, secondTonic: "perfect" } },
-      { chord: "VIm", key: "C", actual: { ...allFalse, thirdTonic: "perfect" } },
-      { chord: "VIIm-5", key: "C", actual: { ...allFalse, secondDominant: "perfect" } },
-      { chord: "I7", key: "C", actual: { ...allFalse, tonic: "perfect" } },
+      { chord: "I", key: "C", actual: { ...allFalse, tonic: true, } },
+      { chord: "V", key: "C", actual: { ...allFalse, dominant: true } },
+      { chord: "IV", key: "C", actual: { ...allFalse, subdominant: true } },
+      { chord: "IIm", key: "C", actual: { ...allFalse, secondSubDominant: true } },
+      { chord: "IIIm", key: "C", actual: { ...allFalse, secondTonic: true } },
+      { chord: "VIm", key: "C", actual: { ...allFalse, thirdTonic: true } },
+      { chord: "VIIm-5", key: "C", actual: { ...allFalse, secondDominant: true } },
+      { chord: "I7", key: "C", actual: { ...allFalse, tonic: true } },
+
+      { chord: "I", key: "D", actual: { ...allFalse, tonic: true, } },
+      { chord: "V", key: "D", actual: { ...allFalse, dominant: true } },
+      { chord: "IV", key: "D", actual: { ...allFalse, subdominant: true } },
+      { chord: "IIm", key: "D", actual: { ...allFalse, secondSubDominant: true } },
+      { chord: "IIIm", key: "D", actual: { ...allFalse, secondTonic: true } },
+      { chord: "VIm", key: "D", actual: { ...allFalse, thirdTonic: true } },
+      { chord: "VIIm-5", key: "D", actual: { ...allFalse, secondDominant: true } },
+      { chord: "I7", key: "D", actual: { ...allFalse, tonic: true } },
+
+      { chord:'D', key: 'D', actual: { ...allFalse, tonic: true } },
+      { chord: 'G', key: 'D', actual: { ...allFalse, subdominant: true } },
+      { chord: 'A', key: 'D', actual: { ...allFalse, dominant: true } },
+      { chord: 'F#m', key: 'D', actual: { ...allFalse, secondTonic: true } },
 
       // sameroot
-      { chord: "IVsus4", key: "F", actual: { ...allFalse, dominant: "sameRoot" } },
+      // { chord: "IVsus4", key: "F", actual: { ...allFalse, dominant: "sameRoot" } },
     ] satisfies Array<{ chord: string; key: string; actual: ChordFunctionMatch }>,
   )("works for $chord on $key", ({ chord, key, actual }) => {
     expect(getChordFunctionOnKey(chord, key).data).toMatchObject(actual);

--- a/pkgs/harnica-midi/src/analysis/getChordFunctionOnKey.ts
+++ b/pkgs/harnica-midi/src/analysis/getChordFunctionOnKey.ts
@@ -4,16 +4,14 @@ import { formatNote } from "@/internals/chord-assembler";
 import { getDegreeDetailByChordName } from "@/internals/conversion/getDegreeDetailByChordName";
 import { Maybe, maybe } from "@/utils/Maybe";
 
-type MatchLevel = "perfect" | "sameRoot" | false;
-
 export type ChordFunctionMatch = {
-  tonic: MatchLevel;
-  secondTonic: MatchLevel;
-  thirdTonic: MatchLevel;
-  dominant: MatchLevel;
-  secondDominant: MatchLevel;
-  subdominant: MatchLevel;
-  secondSubDominant: MatchLevel;
+  tonic: boolean;
+  secondTonic: boolean;
+  thirdTonic: boolean;
+  dominant: boolean;
+  secondDominant: boolean;
+  subdominant: boolean;
+  secondSubDominant: boolean;
 };
 
 /**
@@ -57,14 +55,8 @@ export function getChordFunctionOnKey(
   return maybe.ok(
     Object.fromEntries(
       Object.entries(harmonicsResult.data).map(([key, harmony]) => {
-        return [
-          key,
-          // prettier-ignore
-          normalized.chordName === harmony.chordName ? "perfect"
-          : normalized.rootName === harmony.root ? "sameRoot"
-          : false,
-        ];
+        return [key, normalized.rootName === harmony.root];
       }, {}),
-    ) as Record<keyof typeof harmonicsResult.data, MatchLevel>,
+    ) as Record<keyof typeof harmonicsResult.data, boolean>,
   );
 }

--- a/pkgs/harnica-midi/src/suggests/getTDSChordsByKeyName.ts
+++ b/pkgs/harnica-midi/src/suggests/getTDSChordsByKeyName.ts
@@ -70,7 +70,7 @@ export function getTDSChordsByKeyName(
 
   const buildSet = (chord: NoteFragment.ChordData): ChordSuggest => ({
     root: opt.degree
-      ? getDegreeNameFromKeyValue(chord.keyValues[0])
+      ? getDegreeNameFromKeyValue(chord.keyValues[0], undefined, { key })
       : getKeyNameByKeyValue(chord.keyValues[0]),
     chordName: getChordDetailFromKeyValues(
       chord.keyValues,

--- a/pkgs/web/src/features/ScoreEditor/components/NoteDetail.tsx
+++ b/pkgs/web/src/features/ScoreEditor/components/NoteDetail.tsx
@@ -591,13 +591,7 @@ export function NoteDetail({
                       onClickListen={onClickChordSuggest}
                       onClickReplace={handleClickChordSuggest}
                       onClickInsertNoteAfter={handleClickInsertAfter}
-                      highlight={
-                        noteFunctions[_key] === "perfect"
-                          ? "green"
-                          : noteFunctions[_key] === "sameRoot"
-                            ? "yellow"
-                            : false
-                      }
+                      highlight={noteFunctions[_key] ? "green" : false}
                     />
                   </TipItemLI>
                 );

--- a/pkgs/web/src/features/ScoreEditor/components/ScoreEditor/LeafRichText.tsx
+++ b/pkgs/web/src/features/ScoreEditor/components/ScoreEditor/LeafRichText.tsx
@@ -29,11 +29,7 @@ type Props = {
   onRequestRelativelizeAllNotes: () => void;
 };
 
-export const LeafRichText = memo(function LeafRichText(props: Props) {
-  return <NoteLeaf {...props} />;
-});
-
-const NoteLeaf = memo(function NoteLeaf({
+export const LeafRichText = memo(function NoteLeaf({
   fragment,
   className,
   onReplaceNote,
@@ -138,7 +134,9 @@ const NoteLeaf = memo(function NoteLeaf({
     ).data;
     if (!functions) return [];
 
-    return Object.entries(functions).filter(([k, v]) => v != false) as Array;
+    return Object.entries(functions).filter(([k, v]) => v != false) as Array<
+      [keyof typeof functions, boolean]
+    >;
   }, [chord]);
 
   return (
@@ -206,13 +204,9 @@ const NoteLeaf = memo(function NoteLeaf({
           {noteFunctions.length === 0 ? (
             <span className="block opacity-40">N/A</span>
           ) : (
-            noteFunctions.map(([harmFunc, matchness]) =>
-              matchness === "perfect" ? (
+            noteFunctions.map(([harmFunc, isMatched]) =>
+              isMatched ? (
                 <span key={harmFunc} className="block font-bold">
-                  🔑{t(`noteFunctions.${harmFunc}_abbre`)}
-                </span>
-              ) : matchness === "sameRoot" ? (
-                <span key={harmFunc} className="block">
                   🔑{t(`noteFunctions.${harmFunc}_abbre`)}
                 </span>
               ) : null,


### PR DESCRIPTION
Incorrect analysis of chord function from key when Key is other than C.

```
Key=D
G A | F#m | Bm
```

Expected:
G= SubD, A= Dom, E#m=Tonic(2), Bm=Tonic(3)

Actual:
G=N/A, A= SubD, E#m= Sub(2), Bm= Dom